### PR TITLE
Lingo Proposed Changes during review of PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Currently, the following games are supported:
 * Muse Dash
 * DOOM 1993
 * Terraria
+* Lingo
 
 For setup and instructions check out our [tutorials page](https://archipelago.gg/tutorial/).
 Downloads can be found at [Releases](https://github.com/ArchipelagoMW/Archipelago/releases), including compiled

--- a/docs/CODEOWNERS
+++ b/docs/CODEOWNERS
@@ -61,6 +61,9 @@
 # Kingdom Hearts 2
 /worlds/kh2/ @JaredWeakStrike
 
+# Lingo
+/worlds/lingo/ @hatkirby
+
 # Links Awakening DX
 /worlds/ladx/ @zig-for
 

--- a/worlds/lingo/__init__.py
+++ b/worlds/lingo/__init__.py
@@ -64,12 +64,12 @@ class LingoWorld(World):
 
         item_difference = len(self.player_logic.REAL_LOCATIONS) - len(pool)
         if item_difference:
-            trap_percentage = self.options.trap_percentage.value
+            trap_percentage = self.options.trap_percentage
             traps = int(item_difference * trap_percentage / 100.0)
             non_traps = item_difference - traps
 
             if non_traps:
-                skip_percentage = self.options.puzzle_skip_percentage.value
+                skip_percentage = self.options.puzzle_skip_percentage
                 skips = int(non_traps * skip_percentage / 100.0)
                 non_skips = non_traps - skips
 
@@ -106,7 +106,7 @@ class LingoWorld(World):
             **{name: int(value) for name, value in self.options.as_dict(*slot_options).items()},
         }
 
-        if self.options.shuffle_paintings.value:
+        if self.options.shuffle_paintings:
             slot_data["painting_entrance_to_exit"] = self.player_logic.PAINTING_MAPPING
 
         return slot_data

--- a/worlds/lingo/items.py
+++ b/worlds/lingo/items.py
@@ -1,11 +1,12 @@
-from typing import Dict, NamedTuple, Optional, List
+from typing import Dict, List, NamedTuple, Optional, TYPE_CHECKING
 
 from BaseClasses import Item, ItemClassification
-from worlds.AutoWorld import World
-
 from .options import ShuffleDoors
-from .static_logic import get_special_item_id, DOORS_BY_ROOM, PROGRESSION_BY_ROOM, get_door_item_id, \
-    get_door_group_item_id, PROGRESSIVE_ITEMS, get_progressive_item_id
+from .static_logic import DOORS_BY_ROOM, PROGRESSION_BY_ROOM, PROGRESSIVE_ITEMS, get_door_group_item_id, \
+    get_door_item_id, get_progressive_item_id, get_special_item_id
+
+if TYPE_CHECKING:
+    from . import LingoWorld
 
 
 class ItemData(NamedTuple):
@@ -18,19 +19,19 @@ class ItemData(NamedTuple):
     door_ids: List[str]
     painting_ids: List[str]
 
-    def should_include(self, world: World) -> bool:
+    def should_include(self, world: "LingoWorld") -> bool:
         if self.mode == "colors":
-            return world.options.shuffle_colors.value > 0
+            return world.options.shuffle_colors > 0
         elif self.mode == "doors":
-            return world.options.shuffle_doors.value != ShuffleDoors.option_none
+            return world.options.shuffle_doors != ShuffleDoors.option_none
         elif self.mode == "orange tower":
             # door shuffle is on and tower isn't progressive
-            return world.options.shuffle_doors.value != ShuffleDoors.option_none \
-                and not world.options.progressive_orange_tower.value
+            return world.options.shuffle_doors != ShuffleDoors.option_none \
+                and not world.options.progressive_orange_tower
         elif self.mode == "complex door":
-            return world.options.shuffle_doors.value == ShuffleDoors.option_complex
+            return world.options.shuffle_doors == ShuffleDoors.option_complex
         elif self.mode == "door group":
-            return world.options.shuffle_doors.value == ShuffleDoors.option_simple
+            return world.options.shuffle_doors == ShuffleDoors.option_simple
         elif self.mode == "special":
             return False
         else:
@@ -82,14 +83,14 @@ def load_item_data():
                                          ItemClassification.progression, "door group", group_door_ids, [])
 
     special_items: Dict[str, ItemClassification] = {
-        ":)": ItemClassification.filler,
+        ":)":                        ItemClassification.filler,
         "The Feeling of Being Lost": ItemClassification.filler,
-        "Wanderlust": ItemClassification.filler,
-        "Empty White Hallways": ItemClassification.filler,
-        "Slowness Trap": ItemClassification.trap,
-        "Iceland Trap": ItemClassification.trap,
-        "Atbash Trap": ItemClassification.trap,
-        "Puzzle Skip": ItemClassification.useful,
+        "Wanderlust":                ItemClassification.filler,
+        "Empty White Hallways":      ItemClassification.filler,
+        "Slowness Trap":             ItemClassification.trap,
+        "Iceland Trap":              ItemClassification.trap,
+        "Atbash Trap":               ItemClassification.trap,
+        "Puzzle Skip":               ItemClassification.useful,
     }
 
     for item_name, classification in special_items.items():

--- a/worlds/lingo/locations.py
+++ b/worlds/lingo/locations.py
@@ -1,9 +1,8 @@
 from enum import Flag, auto
-from typing import Dict, NamedTuple, List
+from typing import Dict, List, NamedTuple
 
 from BaseClasses import Location
-
-from .static_logic import RoomAndPanel, PANELS_BY_ROOM, get_panel_location_id, DOORS_BY_ROOM, get_door_location_id
+from .static_logic import DOORS_BY_ROOM, PANELS_BY_ROOM, RoomAndPanel, get_door_location_id, get_panel_location_id
 
 
 class LocationClassification(Flag):
@@ -45,7 +44,7 @@ def load_location_data():
 
     for room_name, panels in PANELS_BY_ROOM.items():
         for panel_name, panel in panels.items():
-            locat_name = f"{room_name} - {panel_name}"
+            location_name = f"{room_name} - {panel_name}"
 
             classification = LocationClassification.insanity
             if panel.check:
@@ -54,7 +53,7 @@ def load_location_data():
                 if not panel.exclude_reduce:
                     classification |= LocationClassification.reduced
 
-            ALL_LOCATION_TABLE[locat_name] = \
+            ALL_LOCATION_TABLE[location_name] = \
                 LocationData(get_panel_location_id(room_name, panel_name), room_name,
                              [RoomAndPanel(None, panel_name)], classification)
 
@@ -63,18 +62,18 @@ def load_location_data():
             if door.skip_location or door.event or door.panels is None:
                 continue
 
-            locat_name = door.location_name
+            location_name = door.location_name
             classification = LocationClassification.normal
             if door.include_reduce:
                 classification |= LocationClassification.reduced
 
-            if locat_name in ALL_LOCATION_TABLE:
-                new_id = ALL_LOCATION_TABLE[locat_name].code
-                classification |= ALL_LOCATION_TABLE[locat_name].classification
+            if location_name in ALL_LOCATION_TABLE:
+                new_id = ALL_LOCATION_TABLE[location_name].code
+                classification |= ALL_LOCATION_TABLE[location_name].classification
             else:
                 new_id = get_door_location_id(room_name, door_name)
 
-            ALL_LOCATION_TABLE[locat_name] = LocationData(new_id, room_name, door.panels, classification)
+            ALL_LOCATION_TABLE[location_name] = LocationData(new_id, room_name, door.panels, classification)
 
 
 # Initialize location data on the module scope.

--- a/worlds/lingo/player_logic.py
+++ b/worlds/lingo/player_logic.py
@@ -68,12 +68,12 @@ class LingoPlayerLogic:
         self.PAINTING_MAPPING = {}
         self.FORCED_GOOD_ITEM = ""
 
-        door_shuffle = world.options.shuffle_doors.value
-        color_shuffle = world.options.shuffle_colors.value
-        painting_shuffle = world.options.shuffle_paintings.value
-        location_checks = world.options.location_checks.value
-        victory_condition = world.options.victory_condition.value
-        early_color_hallways = world.options.early_color_hallways.value
+        door_shuffle = world.options.shuffle_doors
+        color_shuffle = world.options.shuffle_colors
+        painting_shuffle = world.options.shuffle_paintings
+        location_checks = world.options.location_checks
+        victory_condition = world.options.victory_condition
+        early_color_hallways = world.options.early_color_hallways
 
         if location_checks == LocationChecks.option_reduced and door_shuffle != ShuffleDoors.option_none:
             raise Exception("You cannot have reduced location checks when door shuffle is on, because there would not "
@@ -118,7 +118,7 @@ class LingoPlayerLogic:
                                                                 [RoomAndPanel(room_name, panel_name)]))
                     self.EVENT_LOC_TO_ITEM[event_name] = "Mastery Achievement"
 
-                if not panel_data.non_counting and victory_condition == 2:
+                if not panel_data.non_counting and victory_condition == VictoryCondition.option_level_2:
                     event_name = room_name + " - " + panel_name + " (Counted)"
                     self.add_location(room_name, PlayerLocation(event_name, None,
                                                                 [RoomAndPanel(room_name, panel_name)]))
@@ -239,7 +239,7 @@ class LingoPlayerLogic:
     def randomize_paintings(self, world: "LingoWorld") -> bool:
         self.PAINTING_MAPPING.clear()
 
-        door_shuffle = world.options.shuffle_doors.value
+        door_shuffle = world.options.shuffle_doors
 
         # Determine the set of exit paintings. All required-exit paintings are included, as are all
         # required-when-no-doors paintings if door shuffle is off. We then fill the set with random other paintings.

--- a/worlds/lingo/player_logic.py
+++ b/worlds/lingo/player_logic.py
@@ -1,14 +1,15 @@
-from typing import Dict, List, Optional, NamedTuple
-
-from worlds.AutoWorld import World
+from typing import Dict, List, NamedTuple, Optional, TYPE_CHECKING
 
 from .items import ALL_ITEM_TABLE
-from .locations import LocationClassification, ALL_LOCATION_TABLE
-from .static_logic import RoomAndPanel, Door, PROGRESSION_BY_ROOM, ROOMS, DOORS_BY_ROOM, PANELS_BY_ROOM, \
-    PAINTINGS_BY_ROOM, PAINTINGS, PAINTING_EXITS, PAINTING_ENTRANCES, REQUIRED_PAINTING_ROOMS, \
-    REQUIRED_PAINTING_WHEN_NO_DOORS_ROOMS
-from .options import ShuffleDoors, VictoryCondition, LocationChecks
+from .locations import ALL_LOCATION_TABLE, LocationClassification
+from .options import LocationChecks, ShuffleDoors, VictoryCondition
+from .static_logic import DOORS_BY_ROOM, Door, PAINTINGS, PAINTINGS_BY_ROOM, PAINTING_ENTRANCES, PAINTING_EXITS, \
+    PANELS_BY_ROOM, PROGRESSION_BY_ROOM, REQUIRED_PAINTING_ROOMS, REQUIRED_PAINTING_WHEN_NO_DOORS_ROOMS, ROOMS, \
+    RoomAndPanel
 from .testing import LingoTestOptions
+
+if TYPE_CHECKING:
+    from . import LingoWorld
 
 
 class PlayerLocation(NamedTuple):
@@ -44,9 +45,9 @@ class LingoPlayerLogic:
     def set_door_item(self, room: str, door: str, item: str):
         self.ITEM_BY_DOOR.setdefault(room, {})[door] = item
 
-    def handle_non_grouped_door(self, room_name: str, door_data: Door, world: World):
+    def handle_non_grouped_door(self, room_name: str, door_data: Door, world: "LingoWorld"):
         if room_name in PROGRESSION_BY_ROOM and door_data.name in PROGRESSION_BY_ROOM[room_name]:
-            if room_name == "Orange Tower" and not world.options.progressive_orange_tower.value:
+            if room_name == "Orange Tower" and not world.options.progressive_orange_tower:
                 self.set_door_item(room_name, door_data.name, door_data.item_name)
             else:
                 progressive_item_name = PROGRESSION_BY_ROOM[room_name][door_data.name].item_name
@@ -55,7 +56,7 @@ class LingoPlayerLogic:
         else:
             self.set_door_item(room_name, door_data.name, door_data.item_name)
 
-    def __init__(self, world: World):
+    def __init__(self, world: "LingoWorld"):
         self.ITEM_BY_DOOR = {}
         self.LOCATIONS_BY_ROOM = {}
         self.REAL_LOCATIONS = []
@@ -235,7 +236,7 @@ class LingoPlayerLogic:
                 self.REAL_ITEMS.remove(self.FORCED_GOOD_ITEM)
                 self.REAL_LOCATIONS.remove("Second Room - Good Luck")
 
-    def randomize_paintings(self, world: World) -> bool:
+    def randomize_paintings(self, world: "LingoWorld") -> bool:
         self.PAINTING_MAPPING.clear()
 
         door_shuffle = world.options.shuffle_doors.value

--- a/worlds/lingo/regions.py
+++ b/worlds/lingo/regions.py
@@ -12,17 +12,17 @@ if TYPE_CHECKING:
 
 
 def create_region(room: Room, world: "LingoWorld", player_logic: LingoPlayerLogic) -> Region:
-    region = Region(room.name, world.player, world.multiworld)
+    new_region = Region(room.name, world.player, world.multiworld)
     for location in player_logic.LOCATIONS_BY_ROOM.get(room.name, {}):
-        new_location = LingoLocation(world.player, location.name, location.code, region)
+        new_location = LingoLocation(world.player, location.name, location.code, new_region)
         new_location.access_rule = make_location_lambda(location, room.name, world, player_logic)
-        region.locations.append(new_location)
+        new_region.locations.append(new_location)
         if location.name in player_logic.EVENT_LOC_TO_ITEM:
             event_name = player_logic.EVENT_LOC_TO_ITEM[location.name]
             event_item = LingoItem(event_name, ItemClassification.progression, None, world.player)
             new_location.place_locked_item(event_item)
 
-    return region
+    return new_region
 
 
 def handle_pilgrim_room(regions: Dict[str, Region], world: "LingoWorld", player_logic: LingoPlayerLogic) -> None:
@@ -70,7 +70,7 @@ def create_regions(world: "LingoWorld", player_logic: LingoPlayerLogic) -> None:
             regions[entrance.room].connect(
                 regions[room.name],
                 f"{entrance.room} to {room.name}",
-                lambda state: lingo_can_use_entrance(state, room.name, entrance.door, world.player, player_logic))
+                lambda state, r=room, e=entrance: lingo_can_use_entrance(state, r.name, e.door, world.player, player_logic))
 
     handle_pilgrim_room(regions, world, player_logic)
 

--- a/worlds/lingo/regions.py
+++ b/worlds/lingo/regions.py
@@ -1,87 +1,84 @@
-from BaseClasses import Region, Entrance, ItemClassification
-from worlds.AutoWorld import World
-from worlds.generic.Rules import set_rule
+from typing import Dict, TYPE_CHECKING
 
+from BaseClasses import ItemClassification, Region
 from .items import LingoItem
 from .locations import LingoLocation
 from .player_logic import LingoPlayerLogic
-from .rules import make_location_lambda
-from .static_logic import Room, RoomEntrance, PAINTINGS, ALL_ROOMS
+from .rules import lingo_can_use_entrance, lingo_can_use_pilgrimage, make_location_lambda
+from .static_logic import ALL_ROOMS, PAINTINGS, Room
+
+if TYPE_CHECKING:
+    from . import LingoWorld
 
 
-def create_region(room: Room, world: World, player_logic: LingoPlayerLogic):
-    new_region = Region(room.name, world.player, world.multiworld)
+def create_region(room: Room, world: "LingoWorld", player_logic: LingoPlayerLogic) -> Region:
+    region = Region(room.name, world.player, world.multiworld)
+    for location in player_logic.LOCATIONS_BY_ROOM.get(room.name, {}):
+        new_location = LingoLocation(world.player, location.name, location.code, region)
+        new_location.access_rule = make_location_lambda(location, room.name, world, player_logic)
+        region.locations.append(new_location)
+        if location.name in player_logic.EVENT_LOC_TO_ITEM:
+            event_name = player_logic.EVENT_LOC_TO_ITEM[location.name]
+            event_item = LingoItem(event_name, ItemClassification.progression, None, world.player)
+            new_location.place_locked_item(event_item)
 
-    if room.name in player_logic.LOCATIONS_BY_ROOM.keys():
-        for location in player_logic.LOCATIONS_BY_ROOM[room.name]:
-            new_loc = LingoLocation(world.player, location.name, location.code, new_region)
-            set_rule(new_loc, make_location_lambda(location, room.name, world, player_logic))
-
-            if location.name in player_logic.EVENT_LOC_TO_ITEM:
-                event_item = LingoItem(player_logic.EVENT_LOC_TO_ITEM[location.name], ItemClassification.progression,
-                                       None, player=world.player)
-                new_loc.place_locked_item(event_item)
-
-            new_region.locations.append(new_loc)
-
-    world.multiworld.regions.append(new_region)
+    return region
 
 
-def connect(target: Room, entrance: RoomEntrance, world: World, player_logic: LingoPlayerLogic):
-    target_region = world.multiworld.get_region(target.name, world.player)
-    source_region = world.multiworld.get_region(entrance.room, world.player)
-
-    source_region.connect(target_region, f"{entrance.room} to {target.name}",
-                          lambda state: state.lingo_can_use_entrance(target.name, entrance.door, world.player,
-                                                                     player_logic))
-
-
-def handle_pilgrim_room(world: World, player_logic: LingoPlayerLogic):
-    target_region = world.multiworld.get_region("Pilgrim Antechamber", world.player)
-    source_region = world.multiworld.get_region("Outside The Agreeable", world.player)
-
-    source_region.connect(target_region, "Pilgrimage", lambda state: state.lingo_can_use_pilgrimage(world.player,
-                                                                                                    player_logic))
+def handle_pilgrim_room(regions: Dict[str, Region], world: "LingoWorld", player_logic: LingoPlayerLogic) -> None:
+    target_region = regions["Pilgrim Antechamber"]
+    source_region = regions["Outside The Agreeable"]
+    source_region.connect(
+        target_region,
+        "Pilgrimage",
+        lambda state: lingo_can_use_pilgrimage(state, world.player, player_logic))
 
 
-def connect_painting(warp_enter: str, warp_exit: str, world: World, player_logic: LingoPlayerLogic):
+def connect_painting(regions: Dict[str, Region], warp_enter: str, warp_exit: str, world: "LingoWorld",
+                     player_logic: LingoPlayerLogic) -> None:
     source_painting = PAINTINGS[warp_enter]
     target_painting = PAINTINGS[warp_exit]
 
-    target_region = world.multiworld.get_region(target_painting.room, world.player)
-    source_region = world.multiworld.get_region(source_painting.room, world.player)
+    target_region = regions[target_painting.room]
+    source_region = regions[source_painting.room]
+    source_region.connect(
+        target_region,
+        f"{source_painting.room} to {target_painting.room} (Painting)",
+        lambda state: lingo_can_use_entrance(state, target_painting.room, source_painting.required_door, world.player,
+                                             player_logic))
 
-    source_region.connect(target_region, f"{source_painting.room} to {target_painting.room} (Painting)",
-                          lambda state: state.lingo_can_use_entrance(target_painting.room,
-                                                                     source_painting.required_door, world.player,
-                                                                     player_logic))
 
+def create_regions(world: "LingoWorld", player_logic: LingoPlayerLogic) -> None:
+    regions = {
+        "Menu": Region("Menu", world.player, world.multiworld)
+    }
 
-def create_regions(world: World, player_logic: LingoPlayerLogic):
-    world.multiworld.regions += [
-        Region("Menu", world.player, world.multiworld)
-    ]
+    painting_shuffle = world.options.shuffle_paintings
+    early_color_hallways = world.options.early_color_hallways
 
+    # Instantiate all rooms as regions with their locations first.
     for room in ALL_ROOMS:
-        create_region(room, world, player_logic)
+        regions[room.name] = create_region(room, world, player_logic)
 
-    painting_shuffle = bool(world.options.shuffle_paintings.value)
-    early_color_hallways = bool(world.options.early_color_hallways.value)
-
+    # Connect all created regions now that they exist.
     for room in ALL_ROOMS:
         for entrance in room.entrances:
+            # Don't use the vanilla painting connections if we are shuffling paintings.
             if entrance.painting and painting_shuffle:
-                # Don't use the vanilla painting connections if we are shuffling paintings.
                 continue
 
-            connect(room, entrance, world, player_logic)
+            regions[entrance.room].connect(
+                regions[room.name],
+                f"{entrance.room} to {room.name}",
+                lambda state: lingo_can_use_entrance(state, room.name, entrance.door, world.player, player_logic))
 
-    handle_pilgrim_room(world, player_logic)
+    handle_pilgrim_room(regions, world, player_logic)
 
     if early_color_hallways:
-        world.multiworld.get_region("Starting Room", world.player)\
-            .connect(world.multiworld.get_region("Outside The Undeterred", world.player), "Early Color Hallways")
+        regions["Starting Room"].connect(regions["Outside The Undeterred"], "Early Color Hallways")
 
     if painting_shuffle:
         for warp_enter, warp_exit in player_logic.PAINTING_MAPPING.items():
-            connect_painting(warp_enter, warp_exit, world, player_logic)
+            connect_painting(regions, warp_enter, warp_exit, world, player_logic)
+
+    world.multiworld.regions += regions.values()

--- a/worlds/lingo/rules.py
+++ b/worlds/lingo/rules.py
@@ -27,13 +27,11 @@ def lingo_can_use_pilgrimage(state: CollectionState, player: int, player_logic: 
         ["Art Gallery", "Exit"], ["The Tenacious", "Shortcut to Hub Room"],
         ["Outside The Agreeable", "Tenacious Entrance"]
     ]
-    viable_option = True
     for entrance in fake_pilgrimage:
         if not state.has(player_logic.ITEM_BY_DOOR[entrance[0]][entrance[1]], player):
-            viable_option = False
-            break
+            return False
 
-    return viable_option
+    return True
 
 
 def lingo_can_use_location(state: CollectionState, location: PlayerLocation, room_name: str, world: "LingoWorld",

--- a/worlds/lingo/static_logic.py
+++ b/worlds/lingo/static_logic.py
@@ -1,6 +1,6 @@
-import yaml
+from typing import Dict, List, NamedTuple, Optional, Set
 
-from typing import Dict, NamedTuple, Optional, List, Set
+import yaml
 
 
 class RoomAndDoor(NamedTuple):
@@ -98,8 +98,8 @@ PROGRESSIVE_ITEM_IDS: Dict[str, int] = {}
 
 
 def load_static_data():
-    global PAINTING_EXITS, SPECIAL_ITEM_IDS, PANEL_LOCATION_IDS, DOOR_LOCATION_IDS, DOOR_ITEM_IDS, DOOR_GROUP_ITEM_IDS,\
-        PROGRESSIVE_ITEM_IDS
+    global PAINTING_EXITS, SPECIAL_ITEM_IDS, PANEL_LOCATION_IDS, DOOR_LOCATION_IDS, DOOR_ITEM_IDS, \
+        DOOR_GROUP_ITEM_IDS, PROGRESSIVE_ITEM_IDS
 
     try:
         from importlib.resources import files

--- a/worlds/lingo/test/__init__.py
+++ b/worlds/lingo/test/__init__.py
@@ -1,5 +1,6 @@
 from typing import ClassVar
-from test.TestBase import WorldTestBase
+
+from test.bases import WorldTestBase
 from .. import LingoTestOptions
 
 


### PR DESCRIPTION
Things I noticed in my review that I figured I could PR for instead. Feel free to ask any questions about any changes if you have any.

- Added Lingo and @hatkirby to `README.md` and `docs/CODEOWNERS` documentation.
- Removed redundant use of `.value` in most `self.options` instances.
- Added explicit type for `LingoWorld` instead of `World` in supporting files for better type hinting.
- Removed unneeded imports.
- Converted `fill_slot_data`'s usage of `dataclasses.asdict` to use `self.options.as_dict` method.
- Couple clearer variable names.
- Converted `LogicMixin` use to lone functions as it's not necessary for use.
  - `LogicMixin` does not work on Python versions below 3.10 in an `.apworld` package, pollutes `CollectionState` namespace, and provides no type information on `CollectionState` prior to runtime. So generally, I don't recommend using it unless you have the one specific scenario where it's required (e.g., Ocarina of Time and Super Metroid)
- Removed unnecessary `connect` function from `regions.py`.
- Rely more on Region helper methods instead of manually creating majority of entrances/locations.
- Locally cache region creation to avoid needing to call `multiworld.get_region` which can be slower in certain situations.
- Sort imports. ~~personal preference to be fair~~

Ran a generation of 5-Lingo (mostly random settings) on seed 0 to confirm functionality was not altered by changes. Spoiler logs from before changes and after changes are unaltered, see below.

Outside of these nitpicks, looks very good.

![image](https://github.com/hatkirby/Archipelago/assets/11338376/c4ad2a99-3e13-4d9c-9f6c-6974f02ea3b3)